### PR TITLE
No more visible pig when you sit

### DIFF
--- a/src/main/java/com/purpurmc/sit/events/onSit.java
+++ b/src/main/java/com/purpurmc/sit/events/onSit.java
@@ -136,8 +136,10 @@ public class onSit implements Listener {
             }
         }
 
+        Location spawnLoc = loc.clone();
+        spawnLoc.setY(255);
         String entityType = config.getString("sitables." + offsetmode + ".entity.type");
-        Entity stair = p.getWorld().spawnEntity(loc, EntityType.valueOf(entityType));
+        Entity stair = p.getWorld().spawnEntity(spawnLoc, EntityType.valueOf(entityType));
 
         if (stair instanceof Steerable) {
             Steerable steerable = (Steerable) stair;
@@ -153,9 +155,10 @@ public class onSit implements Listener {
         stair.setInvulnerable(true);
         stair.setSilent(true);
         stair.setMetadata("stair", new FixedMetadataValue(instance, true));
+        stair.teleport(loc);
 
-        stair.addPassenger(p);
-
+        Bukkit.getScheduler().runTaskLater(Sit.getInstance(), () -> stair.addPassenger(p), config.getLong("sitables.ticks_before_mount"));
+        
         if (stair instanceof ArmorStand) {
             ((ArmorStand) stair).setVisible(false);
         }
@@ -163,4 +166,4 @@ public class onSit implements Listener {
             ((LivingEntity)stair).setAI(false);
         }
     }
-}
+ }

--- a/src/main/java/com/purpurmc/sit/events/onSit.java
+++ b/src/main/java/com/purpurmc/sit/events/onSit.java
@@ -157,7 +157,8 @@ public class onSit implements Listener {
         stair.setMetadata("stair", new FixedMetadataValue(instance, true));
         stair.teleport(loc);
 
-        Bukkit.getScheduler().runTaskLater(Sit.getInstance(), () -> stair.addPassenger(p), config.getLong("sitables.ticks_before_mount"));
+        Long ticksBeforeMount = (Long) config.getLong("sitables." + offsetmode + ".ticks_before_mount");
+        Bukkit.getScheduler().runTaskLater(Sit.getInstance(), () -> stair.addPassenger(p), ticksBeforeMount);
         
         if (stair instanceof ArmorStand) {
             ((ArmorStand) stair).setVisible(false);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -49,3 +49,6 @@ sitables:
     check: BLOCKS
     list:
       - END_ROD
+  # Number of ticks before mounting the entity
+  # 1 tick = instant but may see the player glitching in the air for 0.25 seconds
+  ticks_before_mount: 5

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,9 +20,9 @@ sitables:
     #BLOCKDATA, BLOCKS
     check: BLOCKDATA
     list:
-      - org.bukkit.block.data.type.Stairs   
-    # Number of ticks before mounting the entity, increase if players see glitching in the air 
-    ticks_before_mount: 5 
+      - org.bukkit.block.data.type.Stairs
+    # Number of ticks before mounting the entity, increase if players see glitching in the air
+    ticks_before_mount: 5
   slabs:
     entity:
       type: PIG
@@ -34,7 +34,7 @@ sitables:
     check: BLOCKDATA
     list:
       - org.bukkit.block.data.type.Slab
-    ticks_before_mount: 5 
+    ticks_before_mount: 5
   fun:
     # if require is set to true
     # player must have "sit.fun" permission to sit on the block's this layout has
@@ -52,4 +52,4 @@ sitables:
     check: BLOCKS
     list:
       - END_ROD
-    ticks_before_mount: 5 
+    ticks_before_mount: 5

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,7 +20,9 @@ sitables:
     #BLOCKDATA, BLOCKS
     check: BLOCKDATA
     list:
-      - org.bukkit.block.data.type.Stairs
+      - org.bukkit.block.data.type.Stairs   
+    # Number of ticks before mounting the entity, increase if players see glitching in the air 
+    ticks_before_mount: 5 
   slabs:
     entity:
       type: PIG
@@ -32,6 +34,7 @@ sitables:
     check: BLOCKDATA
     list:
       - org.bukkit.block.data.type.Slab
+    ticks_before_mount: 5 
   fun:
     # if require is set to true
     # player must have "sit.fun" permission to sit on the block's this layout has
@@ -49,6 +52,4 @@ sitables:
     check: BLOCKS
     list:
       - END_ROD
-  # Number of ticks before mounting the entity
-  # 1 tick = instant but may see the player glitching in the air for 0.25 seconds
-  ticks_before_mount: 5
+    ticks_before_mount: 5 


### PR DESCRIPTION
Hey, It's me again, messing with your plugin!

I've been playing around to see how we could end up not seeing the pig at all when we sit.

The idea was simply to spawn the entity at Y:255 over the player so the invisibility could apply and only then teleport it back to the player and mount it.
The only problem i had was that the player would mount the pig while it was still in the air, so you would see the sky for 0.25s.

I tried checking the location of the pig to make sure it was at the stairs, but it seems that as soon as the teleport command is called the new location is applied immediately even though the pig is still "traveling" for a few ticks.

So I ended up using the scheduler to wait 5 ticks (0.25s) before mounting and I added it as a config so people can adjust it .
It works well enough for me as 5 ticks is relatively short, it feels responsive and alot more immersive than before (Especially without the saddles).

Anyway, I'm sure there is a better way to implement that than the scheduler but I just started messing around with Java and Bukkit so I might try other stuff.

Let me know if you have any idea of how to implement a verification to prevent the player of mounting the entity too early!

