### PR TITLE
fix: add missing permission message for /sit command

### DIFF
--- a/src/main/java/me/usainsrht/sit/command/SitCommand.java
+++ b/src/main/java/me/usainsrht/sit/command/SitCommand.java
@@ -28,6 +28,8 @@ public class SitCommand extends Command {
             else {
                 sender.sendMessage("/sit reload");
             }
+        } else {
+            sender.sendMessage("Unknown command");
         }
         return true;
     }


### PR DESCRIPTION
Because when player without permission uses /sit they see nothing. It's better send them something, like "Unknown command".